### PR TITLE
docs: document the working setup and deploy path

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,41 +6,62 @@ This branch (`v4`) is a ground-up rebuild. Its purpose is to move every piece of
 
 ## Status
 
-**Phase 0 of 8** — archive and documentation. No application code yet. See [the phase list](#phases).
+**Phase 1 of 8** — foundation. The app, admin panel, database, and media storage exist; there is no design system, content model, or public content yet. See [the phase list](#phases).
 
 ## Stack
 
-| Layer | Choice |
-| --- | --- |
-| Framework | [Next.js](https://nextjs.org) (App Router), `>=16.2.2` |
-| CMS | [Payload](https://payloadcms.com) `>=3.73`, mounted in the same app |
-| Database | [Neon](https://neon.tech) Postgres |
-| Media | [Cloudflare R2](https://developers.cloudflare.com/r2/), S3-compatible adapter |
-| Hosting | [Vercel](https://vercel.com) |
-| Styling | Vanilla CSS — design tokens, CUBE-style composition primitives, CSS Modules |
-| Language | TypeScript, strict |
-| Packages | pnpm |
+| Layer     | Choice                                                                        |
+| --------- | ----------------------------------------------------------------------------- |
+| Framework | [Next.js](https://nextjs.org) (App Router), `16.2.12`                         |
+| CMS       | [Payload](https://payloadcms.com) `3.86.0`, mounted in the same app           |
+| Database  | [Neon](https://neon.tech) Postgres                                            |
+| Media     | [Cloudflare R2](https://developers.cloudflare.com/r2/), S3-compatible adapter |
+| Hosting   | [Vercel](https://vercel.com)                                                  |
+| Styling   | Vanilla CSS — design tokens, CUBE-style composition primitives, CSS Modules   |
+| Language  | TypeScript, strict                                                            |
+| Packages  | pnpm                                                                          |
 
-Payload does not support Next `15.5`–`16.1.x`. The version floor is a hard requirement.
+Versions are pinned exactly, not caret-ranged. Payload couples tightly to Next — it does not support Next `15.5`–`16.1.x` — so upgrades are a deliberate change, not an incidental one.
 
 ## Getting started
 
-> Not yet available — Phase 1 sets this up.
+Requires Node `>=22` (see `.nvmrc`) and pnpm.
 
 ```bash
 pnpm install
-cp .env.example .env   # fill in your own credentials
+cp .env.example .env
+```
+
+Fill in `.env` — every key is documented there, and in [docs/ops/environments.md](docs/ops/environments.md). You need a Neon connection string and Cloudflare R2 credentials; ask the owner. Then:
+
+```bash
+pnpm migrate
 pnpm dev
 ```
 
-The public site runs at `/`, the admin panel at `/admin`.
+The public site runs at [localhost:3000](http://localhost:3000), the admin panel at [/admin](http://localhost:3000/admin). The first visit to `/admin` prompts you to create an account.
+
+**Every variable must be set before anything runs, including the build** — the Payload config reads them while Next collects page data. A missing one fails loudly, naming itself.
+
+### Commands
+
+|                              |                                                                 |
+| ---------------------------- | --------------------------------------------------------------- |
+| `pnpm dev`                   | Dev server                                                      |
+| `pnpm verify`                | lint → typecheck → test → build. Run before committing.         |
+| `pnpm migrate`               | Apply pending migrations                                        |
+| `pnpm migrate:create <name>` | Generate a migration after a schema change                      |
+| `pnpm generate:types`        | Regenerate `payload-types.ts`                                   |
+| `pnpm generate:importmap`    | Regenerate the admin import map after adding an admin component |
+
+Git hooks handle formatting on commit and run the full verify loop on push.
 
 ## Documentation
 
 Docs use progressive disclosure: start narrow, follow links only as far as your task needs.
 
 - **[AGENTS.md](AGENTS.md)** — conventions, non-negotiables, and a map of every other doc. Start here.
-- **DESIGN.md** — visual identity: tokens, type scale, invariants. *(Phase 2)*
+- **DESIGN.md** — visual identity: tokens, type scale, invariants. _(Phase 2)_
 - **[docs/architecture/](docs/architecture/)** — system shape, content model, block catalogue
 - **[docs/design/](docs/design/)** — layout primitives, tokens, components
 - **[docs/workflows/](docs/workflows/)** — verify loop, how to add a block or page, how to edit content
@@ -50,26 +71,26 @@ Docs use progressive disclosure: start narrow, follow links only as far as your 
 
 ## Phases
 
-| # | Phase | State |
-| --- | --- | --- |
-| 0 | Archive, extract, document skeleton | in progress |
-| 1 | Foundation — app, database, storage, CI, deploy | |
-| 2 | Design system — tokens, primitives, components | |
-| 3 | Content model — collections, globals, blocks | |
-| 4 | Rendering — layouts, pages, block renderers | |
-| 5 | Content migration — seed script | |
-| 6 | Launch — SEO, performance, accessibility, cutover | |
-| 7 | Forms — registration and careers *(deferred)* | |
-| 8 | Localisation — activate additional languages *(deferred)* | |
+| #   | Phase                                                     | State       |
+| --- | --------------------------------------------------------- | ----------- |
+| 0   | Archive, extract, document skeleton                       | done        |
+| 1   | Foundation — app, database, storage, CI, deploy           | in progress |
+| 2   | Design system — tokens, primitives, components            |             |
+| 3   | Content model — collections, globals, blocks              |             |
+| 4   | Rendering — layouts, pages, block renderers               |             |
+| 5   | Content migration — seed script                           |             |
+| 6   | Launch — SEO, performance, accessibility, cutover         |             |
+| 7   | Forms — registration and careers _(deferred)_             |             |
+| 8   | Localisation — activate additional languages _(deferred)_ |             |
 
 ## History
 
-| Ref | What |
-| --- | --- |
-| `main` | Currently the live v3 site |
-| `v3-final` (tag) | Exact state of the live site at the start of the rebuild |
-| `v3` (branch) | The Astro implementation — reference only, never copied |
-| `archive/v4-payload-template` | An abandoned 2025 attempt on the stock Payload starter |
+| Ref                           | What                                                     |
+| ----------------------------- | -------------------------------------------------------- |
+| `main`                        | Currently the live v3 site                               |
+| `v3-final` (tag)              | Exact state of the live site at the start of the rebuild |
+| `v3` (branch)                 | The Astro implementation — reference only, never copied  |
+| `archive/v4-payload-template` | An abandoned 2025 attempt on the stock Payload starter   |
 
 ## Licence
 

--- a/docs/ops/deploy.md
+++ b/docs/ops/deploy.md
@@ -3,9 +3,20 @@
 **Purpose:** how code reaches production, and how to get back when it shouldn't have.
 **Read this when:** shipping, or something is broken in production.
 
-> **Status: not yet configured.** Phase 1 sets up the pipeline; Phase 6 covers the DNS cutover.
+> **Status: pipeline live, cutover pending.** Preview and production deploys work as described. The DNS switch is Phase 6.
 
 ---
+
+## Vercel setup
+
+**Environment variables must exist before the first deploy succeeds.** The Payload config reads them while Next collects page data, so a project with no variables fails at build with `Missing required environment variable: …` — this is the intended behaviour, not a misconfiguration to work around. Set every key from [environments.md](environments.md) for **both** Preview and Production.
+
+Two must differ between environments:
+
+- **`PAYLOAD_SECRET`** — a distinct value per environment. Sharing it means a session token minted against preview is valid against production.
+- **`NEXT_PUBLIC_SERVER_URL`** — the actual origin of that environment. A localhost value left in preview breaks preview callbacks and absolute URLs.
+
+Preview deploys point at the **dev** Neon branch and dev R2 bucket. Previews exist to review code; pointing them at production data risks an editor's real content being altered by a branch that never merges.
 
 ## Pipeline
 
@@ -28,6 +39,8 @@ Automated contributors never push to `main`. The owner merges.
 **Bad data** — Neon's point-in-time restore. Note the ordering trap: rolling back code does **not** roll back a migration. If a deploy migrated the schema, restore the database to a point before it, then redeploy the older code. Rolling back code alone against a migrated database usually fails in a worse way than the original bug.
 
 **Bad content** — Payload version history. Editors restore a previous version of a document themselves; no deploy involved.
+
+**Bad media** — deleting or replacing a file takes effect in the database immediately, but the media domain caches for four hours, so the old image keeps being served from the edge. See [environments.md](environments.md#media-serving-and-cache).
 
 ## Launch cutover (Phase 6)
 


### PR DESCRIPTION
Third of three PRs for Phase 1. **Stacked on #5**, which is stacked on #4. Bases retarget automatically as each merges.

Docs only — no code.

## What

- **README getting-started** is now real rather than a placeholder: install, env, migrate, dev, plus the command table.
- **`docs/ops/deploy.md`** records the Vercel requirements Phase 1 established.
- Phase 0 marked done, Phase 1 in progress; stack table pinned to installed versions rather than floors.

## The Vercel constraint worth knowing

**Environment variables must exist before the first deploy can succeed.** The Payload config reads them while Next collects page data, so a project with no variables fails at build with `Missing required environment variable: …`.

This is deliberate. The alternative — tolerating missing values at build time — turns a deploy that *cannot* work into a deploy that *half* works, failing later at whichever request first needs the variable. Failing at build is the better trade.

Two values must differ between environments, and both are easy to get wrong by copy-pasting `.env`:

- **`PAYLOAD_SECRET`** — distinct per environment, or a session token minted against preview is valid against production.
- **`NEXT_PUBLIC_SERVER_URL`** — the real origin of that environment. A leftover localhost breaks preview callbacks.

Previews point at the **dev** Neon branch and dev R2 bucket on purpose: previews review code, and a branch that never merges should not be able to alter an editor's real content.

## Still outstanding for Phase 1

The Vercel deploy is red until the environment variables are added to the project. That is owner-only work — this PR documents exactly what to set. Once set, the remaining verification is confirming the preview serves both the placeholder page and a working `/admin`.